### PR TITLE
Fix date format: includes seconds to match expected format on order analysis

### DIFF
--- a/src/main/java/com/konduto/sdk/models/KondutoOrder.java
+++ b/src/main/java/com/konduto/sdk/models/KondutoOrder.java
@@ -309,7 +309,7 @@ public final class KondutoOrder extends KondutoModel {
 		this.purchasedAt = serializeDate(purchased_at);
 	}
 
-	public static final String dateFormat = "yyyy-MM-dd'T'HH:mmZ";
+	public static final String dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ";
 
 	private Date deserializeDate(String date) throws JsonParseException {
 		try {


### PR DESCRIPTION
Ao enviar o `KondutoOrder` para análise é retornado um erro de validação do campo `purchased_at`. 

O formato esperado é `yyyy-MM-dd'T'HH:mm:ss` porém está sendo formatado para `yyyy-MM-dd'T'HH:mm`