### PR TITLE
Fixing HttpClient 3.1 Security Vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,12 +33,17 @@ sourceSets {
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-    implementation 'commons-httpclient:commons-httpclient:3.1'
-    implementation 'commons-codec:commons-codec:1.15'
+    implementation('commons-httpclient:commons-httpclient:3.1') {
+        exclude group: 'commons-codec', module: 'commons-codec'
+        exclude group: 'junit', module: 'junit'
+    }
+    implementation('commons-codec:commons-codec:1.15') {
+        exclude group: 'junit', module: 'junit'
+    }
     implementation 'com.google.code.gson:gson:2.9.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.github.tomakehurst:wiremock-jre8:2.33.2'
@@ -117,7 +122,7 @@ publishing {
 }
 
 javadoc {
-    if(JavaVersion.current().isJava9Compatible()) {
+    if (JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,10 @@ repositories {
 
 dependencies {
     implementation 'commons-httpclient:commons-httpclient:3.1'
+    implementation 'commons-codec:commons-codec:1.15'
     implementation 'com.google.code.gson:gson:2.9.0'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.github.tomakehurst:wiremock:2.27.2'
+    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.33.2'
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
An HttpClient 3.1 security vulnerability was found in the encryption codec.